### PR TITLE
Backport custom mod property bridge to 1.20.1

### DIFF
--- a/src/main/java/net/fabricmc/loader/impl/FMLModMetadata.java
+++ b/src/main/java/net/fabricmc/loader/impl/FMLModMetadata.java
@@ -16,20 +16,29 @@
 
 package net.fabricmc.loader.impl;
 
+import com.electronwill.nightconfig.core.UnmodifiableConfig;
+import com.mojang.logging.LogUtils;
 import net.fabricmc.loader.api.Version;
 import net.fabricmc.loader.api.metadata.*;
+import net.fabricmc.loader.impl.metadata.CustomValueImpl;
 import net.fabricmc.loader.impl.metadata.SimplePerson;
 import net.minecraftforge.forgespi.language.IModInfo;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
 
 import java.util.*;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static cpw.mods.modlauncher.api.LamdbaExceptionUtils.uncheck;
 
 public class FMLModMetadata implements ModMetadata {
+    private static final Logger LOGGER = LogUtils.getLogger();
+
     private final IModInfo modInfo;
     private final Version version;
     private final Collection<Person> authors;
+    private final Map<String, CustomValue> customValues;
 
     public FMLModMetadata(IModInfo modInfo) {
         this.modInfo = modInfo;
@@ -38,6 +47,8 @@ public class FMLModMetadata implements ModMetadata {
             .flatMap(obj -> obj instanceof List list ? ((List<String>) list).stream() : Stream.of(obj.toString().split(",")))
             .<Person>map(SimplePerson::new)
             .toList();
+        this.customValues = this.modInfo.getModProperties().entrySet().stream()
+                .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> convertModProperty(e.getValue())));
     }
 
     @Override
@@ -115,21 +126,43 @@ public class FMLModMetadata implements ModMetadata {
 
     @Override
     public boolean containsCustomValue(String key) {
-        return false;
+        return this.modInfo.getModProperties().containsKey(key);
     }
 
     @Override
     public CustomValue getCustomValue(String key) {
-        return null;
+        return this.customValues.get(key);
     }
 
     @Override
     public Map<String, CustomValue> getCustomValues() {
-        return Map.of();
+        return this.customValues;
     }
 
     @Override
     public boolean containsCustomElement(String key) {
-        return false;
+        return containsCustomValue(key);
+    }
+
+    @Nullable
+    private static CustomValue convertModProperty(@Nullable Object value) {
+        if (value == null) {
+            return CustomValueImpl.NULL;
+        } else if (value instanceof UnmodifiableConfig config) {
+            Map<String, CustomValue> entries = config.entrySet().stream()
+                    .collect(Collectors.toMap(UnmodifiableConfig.Entry::getKey, e -> convertModProperty(e.getValue())));
+            return new CustomValueImpl.ObjectImpl(entries);
+        } else if (value instanceof List<?> list) {
+            List<CustomValue> contents = list.stream().map(FMLModMetadata::convertModProperty).toList();
+            return new CustomValueImpl.ArrayImpl(contents);
+        } else if (value instanceof Boolean bool) {
+            return bool ? CustomValueImpl.BOOLEAN_TRUE : CustomValueImpl.BOOLEAN_FALSE;
+        } else if (value instanceof String str) {
+            return new CustomValueImpl.StringImpl(str);
+        } else if (value instanceof Number num) {
+            return new CustomValueImpl.NumberImpl(num);
+        }
+        LOGGER.warn("Ignoring custom mod property value '{}' of unsupported type '{}'", value, value.getClass().getName());
+        return null;
     }
 }

--- a/src/main/java/net/fabricmc/loader/impl/ModContainerImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/ModContainerImpl.java
@@ -63,7 +63,7 @@ public class ModContainerImpl extends net.fabricmc.loader.ModContainer {
 
     @Override
     public Path getRootPath() {
-        return this.modInfo.getOwningFile().getFile().findResource(".");
+        return this.modInfo.getOwningFile().getFile().findResource("/");
     }
 
     @Override

--- a/src/main/java/net/fabricmc/loader/impl/metadata/CustomValueImpl.java
+++ b/src/main/java/net/fabricmc/loader/impl/metadata/CustomValueImpl.java
@@ -29,10 +29,10 @@ import java.util.Objects;
 import net.fabricmc.loader.api.metadata.CustomValue;
 import net.fabricmc.loader.impl.lib.gson.JsonReader;
 
-abstract class CustomValueImpl implements CustomValue {
-	static final CustomValue BOOLEAN_TRUE = new BooleanImpl(true);
-	static final CustomValue BOOLEAN_FALSE = new BooleanImpl(false);
-	static final CustomValue NULL = new NullImpl();
+public abstract class CustomValueImpl implements CustomValue {
+	public static final CustomValue BOOLEAN_TRUE = new BooleanImpl(true);
+	public static final CustomValue BOOLEAN_FALSE = new BooleanImpl(false);
+	public static final CustomValue NULL = new NullImpl();
 
 	public static CustomValue readCustomValue(JsonReader reader) throws IOException, ParseMetadataException {
 		switch (reader.peek()) {
@@ -125,10 +125,10 @@ abstract class CustomValueImpl implements CustomValue {
 		}
 	}
 
-	private static final class ObjectImpl extends CustomValueImpl implements CvObject {
+	public static final class ObjectImpl extends CustomValueImpl implements CvObject {
 		private final Map<String, CustomValue> entries;
 
-		ObjectImpl(Map<String, CustomValue> entries) {
+		public ObjectImpl(Map<String, CustomValue> entries) {
 			this.entries = Collections.unmodifiableMap(entries);
 		}
 
@@ -158,10 +158,10 @@ abstract class CustomValueImpl implements CustomValue {
 		}
 	}
 
-	private static final class ArrayImpl extends CustomValueImpl implements CvArray {
+	public static final class ArrayImpl extends CustomValueImpl implements CvArray {
 		private final List<CustomValue> entries;
 
-		ArrayImpl(List<CustomValue> entries) {
+		public ArrayImpl(List<CustomValue> entries) {
 			this.entries = Collections.unmodifiableList(entries);
 		}
 
@@ -186,10 +186,10 @@ abstract class CustomValueImpl implements CustomValue {
 		}
 	}
 
-	private static final class StringImpl extends CustomValueImpl {
+	public static final class StringImpl extends CustomValueImpl {
 		final String value;
 
-		StringImpl(String value) {
+		public StringImpl(String value) {
 			this.value = value;
 		}
 
@@ -199,10 +199,10 @@ abstract class CustomValueImpl implements CustomValue {
 		}
 	}
 
-	private static final class NumberImpl extends CustomValueImpl {
+	public static final class NumberImpl extends CustomValueImpl {
 		final Number value;
 
-		NumberImpl(Number value) {
+		public NumberImpl(Number value) {
 			this.value = value;
 		}
 


### PR DESCRIPTION
This PR backports two features via cherry-picking, and especially one that I'd like to have access to for my own mods:
- Custom mod property bridging: 63f15bf96d5568d2555882bde0128e60385cd1c7
- Use / for root file path: e9fea0588c6bb3cdc81a16ea2c06735c231a6504